### PR TITLE
build: Arrange sepolicy makefile inclusion correctly

### DIFF
--- a/core/config.mk
+++ b/core/config.mk
@@ -1162,22 +1162,22 @@ dont_bother_goals := out \
 # consistency with those defined in BoardConfig.mk files.
 include $(BUILD_SYSTEM)/android_soong_config_vars.mk
 
-ifeq ($(CALLED_FROM_SETUP),true)
-include $(BUILD_SYSTEM)/ninja_config.mk
-include $(BUILD_SYSTEM)/soong_config.mk
-endif
-
 ifneq ($(BLISS_BUILD),)
 ## We need to be sure the global selinux policies are included
 ## last, to avoid accidental resetting by device configs
 $(eval include device/bliss/sepolicy/common/sepolicy.mk)
+endif
+
+ifeq ($(CALLED_FROM_SETUP),true)
+include $(BUILD_SYSTEM)/ninja_config.mk
+include $(BUILD_SYSTEM)/soong_config.mk
+endif
 
 # Include any vendor specific config.mk file
 -include $(TOPDIR)vendor/*/build/core/config.mk
 
 # Include any vendor specific apicheck.mk file
 -include $(TOPDIR)vendor/*/build/core/apicheck.mk
-endif
 
 -include external/linux-kselftest/android/kselftest_test_list.mk
 -include external/ltp/android/ltp_package_list.mk


### PR DESCRIPTION
Fixes: False positive build errors reading malformed seapp_contexts